### PR TITLE
fix: the generate-image in generate-image.mjs

### DIFF
--- a/codex/skills/impeccable/scripts/generate-image.mjs
+++ b/codex/skills/impeccable/scripts/generate-image.mjs
@@ -256,7 +256,8 @@ if (refs.length) {
   });
 }
 if (!response.ok) {
-  console.error(`generate-image: API error ${response.status}: ${(await response.text()).slice(0, 300)}`);
+  const body = (await response.text()).replaceAll(key, '***REDACTED***').slice(0, 300);
+  console.error(`generate-image: API error ${response.status}: ${body}`);
   process.exit(1);
 }
 const json = await response.json();


### PR DESCRIPTION
## Summary
Fix high severity security issue in `codex/skills/impeccable/scripts/generate-image.mjs`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `codex/skills/impeccable/scripts/generate-image.mjs:206` |
| **Assessment** | Likely exploitable |

**Description**: The generate-image.mjs script correctly loads the OpenAI API key from the OPENAI_API_KEY environment variable rather than hardcoding it. This is proper security practice. However, the key could still be exposed through process listings, debug logs, or error messages if not properly protected at the infrastructure level.

## Evidence

**Exploitation scenario**: An attacker with local system access could potentially observe the OPENAI_API_KEY value through process environment inspection (e.g., /proc/[pid]/environ on Linux), process listings, or application.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a local CLI tool - exploitation requires the attacker to control command-line arguments or input files.

## Changes
- `codex/skills/impeccable/scripts/generate-image.mjs`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sensitive API key values are now removed from error logs, reducing the risk of exposing credentials while preserving existing error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->